### PR TITLE
Api cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "snafu",
- "strum",
+ "strum 0.28.0",
  "tracing",
  "tracing-subscriber",
  "ureq",
@@ -1665,37 +1665,34 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
 dependencies = [
  "chrono",
- "indoc",
  "inventory",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1703,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1715,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1728,9 +1725,9 @@ dependencies = [
 
 [[package]]
 name = "pythonize"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a8f29db331e28c332c63496cfcbb822aca3d7320bc08b655d7fd0c29c50ede"
+checksum = "0b79f670c9626c8b651c0581011b57b6ba6970bb69faf01a7c4c0cfc81c43f95"
 dependencies = [
  "pyo3",
  "serde",
@@ -1828,7 +1825,7 @@ dependencies = [
  "itertools",
  "kasuari",
  "lru",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -1880,7 +1877,7 @@ dependencies = [
  "itertools",
  "line-clipping",
  "ratatui-core",
- "strum",
+ "strum 0.27.2",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -2212,9 +2209,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snafu"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+checksum = "d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6"
 dependencies = [
  "backtrace",
  "snafu-derive",
@@ -2222,9 +2219,9 @@ dependencies = [
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2256,7 +2253,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -2264,6 +2270,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2657,12 +2675,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,9 +257,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -529,9 +529,9 @@ checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -770,19 +770,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1060,9 +1060,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1184,9 +1184,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "line-clipping"
@@ -1199,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1480,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"
@@ -1610,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -1738,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1750,6 +1750,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1914,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ring"
@@ -1958,9 +1964,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
@@ -1971,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -2312,12 +2318,12 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2733,7 +2739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "atomic",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2785,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2798,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2808,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2821,9 +2827,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -3182,9 +3188,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -3308,18 +3314,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ color-eyre = "0.6.3"
 hex = "0.4.3"
 serde = { version = "1.0.200", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-snafu = { version = "0.8.2", features = ["backtrace"] }
-strum = { version = "0.27", features = ["derive"] }
+snafu = { version = "0.9.0", features = ["backtrace"] }
+strum = { version = "0.28", features = ["derive"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 

--- a/TODO.md
+++ b/TODO.md
@@ -70,4 +70,7 @@ file once they are implemented.
 
 - implement `Debug` and `Display` trait for all basic types
 
+- implement `Deref` for newtypes, this way we automatically expose most of the API of the underlying type.
+  We still need to implement `Display`, `From`, etc. manually
+
 - document everything, also use boxes to show structure in source code files (ie: trait impls, etc. see: Symbol.rs as an example)

--- a/kudu-esr/src/signing_request.rs
+++ b/kudu-esr/src/signing_request.rs
@@ -12,9 +12,7 @@ use flate2::read::DeflateDecoder;
 use serde::{Serialize, Serializer, ser::SerializeStruct};
 
 use kudu::{
-    ABIDefinition, ABIError, Action, Bytes, ByteStream, Checksum256, JsonValue, Name,
-    SerializeEnum, SerializeError, Transaction, ABI, PermissionLevel,
-    json, with_location,
+    json, with_location, ABIDefinition, ABIError, Action, ByteStreamView, Bytes, Checksum256, JsonValue, Name, PermissionLevel, SerializeEnum, SerializeError, Transaction, ABI
 };
 
 use tracing::{trace, debug, warn};
@@ -202,8 +200,8 @@ impl SigningRequest {
 
 
         let abi = get_signing_request_abi();
-        let mut ds = ByteStream::from(dec2);
-        abi.decode_variant(&mut ds, "signing_request").context(ABISnafu)
+        let mut view = ByteStreamView::from(&dec2);
+        abi.decode_variant(&mut view, "signing_request").context(ABISnafu)
     }
 
     pub fn decode<T>(esr: T) -> Result<Self, SigningRequestError>
@@ -236,7 +234,7 @@ impl SigningRequest {
     // TODO: `SigningRequest` should be `ABISerializable` instead of having to go through
     //       its JSON representation first
     pub fn encode(&self) -> Bytes {
-        let mut ds = ByteStream::new();
+        let mut ds = Bytes::new();
         let abi = get_signing_request_abi();
 
         // self.encode_actions();
@@ -244,7 +242,7 @@ impl SigningRequest {
 
         let sr = json!(self);
         abi.encode_variant(&mut ds, "signing_request", &sr).unwrap(); // FIXME: remove this `unwrap`
-        ds.into()
+        ds
     }
 }
 

--- a/kudu-macros/src/serde.rs
+++ b/kudu-macros/src/serde.rs
@@ -54,12 +54,12 @@ fn derive_abiserializable_struct(input: &DeriveInput, fields: &FieldsNamed) -> R
         #[doc(hidden)]
         const _: () = {
             impl kudu::ABISerializable for #ident {
-                fn to_bin(&self, s: &mut kudu::ByteStream) {
+                fn to_bin(&self, s: &mut kudu::Bytes) {
                     #(
                         self.#fieldname.to_bin(s);
                     )*
                 }
-                fn from_bin(s: &mut kudu::ByteStream) -> ::core::result::Result<Self, kudu::SerializeError> {
+                fn from_bin(s: &mut kudu::ByteStreamView) -> ::core::result::Result<Self, kudu::SerializeError> {
                     Ok(Self {
                         #(
                             #fieldname: <#fieldtype>::from_bin(s)?,
@@ -112,7 +112,7 @@ fn derive_abiserializable_enum(input: &DeriveInput, enumeration: &DataEnum) -> R
         #[doc(hidden)]
         const _: () = {
             impl kudu::ABISerializable for #ident {
-                fn to_bin(&self, s: &mut kudu::ByteStream) {
+                fn to_bin(&self, s: &mut kudu::Bytes) {
                     match *self {
                         #(
                             #ident::#var_idents(ref __field0) => {
@@ -122,7 +122,7 @@ fn derive_abiserializable_enum(input: &DeriveInput, enumeration: &DataEnum) -> R
                         )*
                     }
                 }
-                fn from_bin(s: &mut kudu::ByteStream) -> ::core::result::Result<Self, kudu::SerializeError> {
+                fn from_bin(s: &mut kudu::ByteStreamView) -> ::core::result::Result<Self, kudu::SerializeError> {
                     Ok(match kudu::VarUint32::from_bin(s)?.0 {
                         #(
                             #index => #ident::#var_idents(<#var_type>::from_bin(s)?),

--- a/kudu-py/Cargo.toml
+++ b/kudu-py/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 chrono             = { workspace = true }
 kudu = { path = "../kudu" }
-pyo3 = { version = "0.27.0", features = ["multiple-pymethods", "chrono"] }
-pythonize = "0.27.0"
+pyo3 = { version = "0.28.0", features = ["multiple-pymethods", "chrono"] }
+pythonize = "0.28.0"
 serde = { version = "1.0.200", features = ["derive"] }
 crabtime = "1.1.4"

--- a/kudu-py/src/chain.rs
+++ b/kudu-py/src/chain.rs
@@ -12,7 +12,7 @@ pub mod kudu_chain {
 
     use kudu::chain::{Action, PermissionLevel, SignedTransaction, Transaction};
     use kudu::{
-        ABISerializable, AccountName, ActionName, Bytes, ByteStream, JsonValue, Name, PermissionName,
+        ABISerializable, AccountName, ActionName, Bytes, JsonValue, Name, PermissionName,
     };
 
     use crate::api::kudu_api::PyAPIClient;
@@ -191,7 +191,7 @@ pub mod kudu_chain {
 
         #[getter]
         fn get_data(&self) -> &[u8] {
-            &self.0.data.0[..]
+            self.0.data.as_bytes()
         }
 
         fn decode_data<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
@@ -275,7 +275,7 @@ pub mod kudu_chain {
             let exts: Vec<Bound<'py, PyTuple>> = self.0
                 .transaction_extensions
                 .iter()
-                .map(|(ext_type, data)| (ext_type, PyBytes::new(py, data.as_ref())).into_pyobject(py).unwrap())  // unwrap should be safe
+                .map(|(ext_type, data)| (ext_type, PyBytes::new(py, data.as_bytes())).into_pyobject(py).unwrap())  // unwrap should be safe
                 .collect();
             PyList::new(py, exts).unwrap()  // unwrap should be safe
         }

--- a/kudu-py/src/crypto.rs
+++ b/kudu-py/src/crypto.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 pub mod kudu_crypto {
     use pyo3::prelude::*;
 
-    use kudu::{ABISerializable, ByteStream, PrivateKey, PublicKey};
+    use kudu::{ABISerializable, PrivateKey, PublicKey};
 
     use crate::util::{gen_bytes_conversion, value_err};
 

--- a/kudu-py/src/lib.rs
+++ b/kudu-py/src/lib.rs
@@ -35,7 +35,7 @@ mod kudu {
     use pyo3::prelude::*;
     use pyo3::types::PyString;
 
-    use kudu::{ABISerializable, ByteStream, Name};
+    use kudu::{ABISerializable, Name};
 
     #[pymodule_export]
     use crate::abi::kudu_abi;

--- a/kudu-py/src/time.rs
+++ b/kudu-py/src/time.rs
@@ -11,7 +11,7 @@ pub mod kudu_time {
 
     use chrono::{DateTime, Datelike, NaiveDateTime, Timelike, Utc};
 
-    use kudu::{ABISerializable, ByteStream, TimePoint, TimePointSec};
+    use kudu::{ABISerializable, TimePoint, TimePointSec};
 
     use crate::util::{
         gen_bytes_conversion, gen_default_repr, gen_default_str, gen_convert_getters, value_err

--- a/kudu-py/src/util.rs
+++ b/kudu-py/src/util.rs
@@ -28,16 +28,17 @@ fn _gen_default_repr(struct_name: String) {
     crabtime::output! {
         #[pymethods]
         impl {{struct_name}} {
-            pub fn __repr__(&self) -> String {
-                let mut module = <Self as ::pyo3::PyTypeInfo>::MODULE.unwrap_or("unknown").to_string();
+            pub fn __repr__<'py>(&self, py: Python<'py>) -> PyResult<String> {
+                let pytype = <Self as ::pyo3::PyTypeInfo>::type_object(py);
+                let pymodule = pytype.module()?;
+                let module = pymodule.to_str()?;
+                let classname = pytype.name()?;
                 // only keep the root module as we import all in it anyway
-                if let Some(idx) = module.find('.') {
-                    module.truncate(idx);
-                }
-                format!("<{}.{}: {}>",
-                        module,
-                        <Self as ::pyo3::PyTypeInfo>::NAME,
-                        self.0)
+                let module = match module.find('.') {
+                    Some(idx) => &module[..idx],
+                    None => module,
+                };
+                Ok(format!("<{}.{}: {}>", module, classname.to_str()?, self.0))
             }
         }
     }

--- a/kudu-py/src/util.rs
+++ b/kudu-py/src/util.rs
@@ -61,7 +61,7 @@ fn _gen_bytes_conversion(struct_name: String) {
         #[pymethods]
         impl {{struct_name}} {
             pub fn __bytes__(&self) -> Vec<u8> {
-                let mut b = ByteStream::new();
+                let mut b = ::kudu::Bytes::new();
                 self.0.to_bin(&mut b);
                 b.into()
             }

--- a/kudu/TODO.md
+++ b/kudu/TODO.md
@@ -7,6 +7,10 @@ NOTE: this should be fixed, or at least a resolution for this should be decided 
 
 - clean abi.rs
 
+- have a macro that reads an ABI definition from a json file and generates rust code
+  with statically-typed method names. This gives us auto-complete, and we can update it
+  easily by just downloading a new json abi definition.
+
 - the `ABISerializable` trait or the `ByteStream` struct needs to be revised:
   currently, `from_bin()` needs a `ByteStream` however the latter owns its data,
   meaning that if we only have a `&[u8]` we need to make a copy of the whole data
@@ -18,6 +22,7 @@ NOTE: this should be fixed, or at least a resolution for this should be decided 
   - a read-only `ByteStream` needs to be able to be cheaply created from `&[u8]`
   - (maybe?) we introduce a new `Cursor` struct (trait?) that can be created either from
     a `&[u8]` or by a `ByteStream`
+    BETTER: we introduce a `ByteStreamView` struct and pass this instead to `from_bin()`
 
 - find a way to declare extension fields on native Rust structs. We can easily
   annotate them using attributes that are recognized by the `derive(ABISerializable)`

--- a/kudu/src/abi/definition.rs
+++ b/kudu/src/abi/definition.rs
@@ -7,7 +7,7 @@ use snafu::{ensure, ResultExt};
 
 use crate::abiserializable::{ABISerializable, ABISnafu};
 use crate::{
-    ByteStream, SerializeError, JsonValue, ActionName, TableName,
+    Bytes, ByteStreamView, SerializeError, JsonValue, ActionName, TableName,
     abi::serializer::ABI,
     abi::error::{ABIError, JsonSnafu, DeserializeSnafu, VersionSnafu, IncompatibleVersionSnafu},
     abi::data::{ABI_SCHEMA, CONTRACT_ABI}
@@ -129,7 +129,7 @@ impl ABIDefinition {
         ABIDefinition::from_str(&v.to_string())
     }
 
-    pub fn decode(data: &mut ByteStream) -> Result<Self> {
+    pub fn decode(data: &mut ByteStreamView) -> Result<Self> {
         // FIXME: check how to deserialize properly the different versions: 1.0, 1.1, 1.2, ...
         let version = String::from_bin(data).context(DeserializeSnafu { what: "version" })?;
 
@@ -165,7 +165,7 @@ impl ABIDefinition {
         Self::from_variant(&abi)
     }
 
-    pub fn encode(&self, stream: &mut ByteStream) -> Result<()> {
+    pub fn encode(&self, stream: &mut Bytes) -> Result<()> {
         let parser = bin_abi_parser();
         parser.encode(stream, &self.version);
         parser.encode_variant(stream, "typedef[]", &json!(self.types))?;
@@ -226,10 +226,10 @@ impl Default for ABIDefinition {
 
 // FIXME: review this, can't we have a single `to_bin`/`encode` method instead of this duplication?
 impl ABISerializable for ABIDefinition {
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         self.encode(stream).unwrap()  // safe unwrap
     }
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         ABIDefinition::decode(stream).context(ABISnafu)
     }
 }
@@ -299,12 +299,12 @@ mod tests {
         });
 
         let abi = ABI::from_definition(&abi).unwrap();  // safe unwrap
-        let mut ds = ByteStream::new();
+        let mut ds = Bytes::new();
         abi.encode_variant(&mut ds, "bar", &obj).unwrap();
 
-        assert_eq!(&ds.hex_data().to_uppercase(), "036F6E65020100000000000028CF01040166016F01750172");
+        assert_eq!(&ds.to_hex().to_uppercase(), "036F6E65020100000000000028CF01040166016F01750172");
 
-        let dec = abi.decode_variant(&mut ds, "bar")?;
+        let dec = abi.decode_variant(&mut ds.view(), "bar")?;
         assert_eq!(dec.to_string(), r#"{"one":"one","two":2,"three":"two","four":["f","o","u","r"]}"#);
 
         Ok(())

--- a/kudu/src/abi/serializer.rs
+++ b/kudu/src/abi/serializer.rs
@@ -11,7 +11,7 @@ use tracing::{debug, warn, instrument};
 
 use crate::{
     AntelopeType, AntelopeValue, Bytes, Name, VarUint32, TypeName,
-    ABIDefinition, ByteStream, ABISerializable,
+    ABIDefinition, ByteStreamView, ABISerializable,
     abi::error::*,
     abi::definition::{
         TypeName as TypeNameOwned, Struct, Variant
@@ -69,7 +69,7 @@ impl ABI {
     }
 
     pub fn from_bin_abi(abi: &[u8]) -> Result<Self> {
-        let mut data = ByteStream::from(abi.to_owned());
+        let mut data = ByteStreamView::from(abi);
         let abi_def = ABIDefinition::decode(&mut data)?;
         Self::from_definition(&abi_def)
     }
@@ -243,18 +243,18 @@ impl ABI {
     where
         T: Into<TypeName<'a>>
     {
-        let mut ds = ByteStream::new();
+        let mut ds = Bytes::new();
         self.encode_variant(&mut ds, typename.into(), obj)?;
-        Ok(ds.into())
+        Ok(ds)
     }
 
     #[inline]
-    pub fn encode<T: ABISerializable>(&self, stream: &mut ByteStream, obj: &T) {
+    pub fn encode<T: ABISerializable>(&self, stream: &mut Bytes, obj: &T) {
         obj.to_bin(stream)
     }
 
     #[inline]
-    pub fn encode_variant<'a, T>(&self, ds: &mut ByteStream, typename: T, object: &JsonValue)
+    pub fn encode_variant<'a, T>(&self, ds: &mut Bytes, typename: T, object: &JsonValue)
                                  -> Result<(), ABIError>
     where
         T: Into<TypeName<'a>>
@@ -263,7 +263,7 @@ impl ABI {
     }
 
     #[instrument(skip(self, ctx, ds))]
-    fn encode_variant_(&self, ctx: &mut VariantToBinaryContext, ds: &mut ByteStream,
+    fn encode_variant_(&self, ctx: &mut VariantToBinaryContext, ds: &mut Bytes,
                        typename: TypeName, object: &JsonValue)
                        -> Result<(), ABIError> {
         // see C++ implementation here: https://github.com/AntelopeIO/spring/blob/main/libraries/chain/abi_serializer.cpp#L493
@@ -374,7 +374,7 @@ impl ABI {
         Ok(())
     }
 
-    fn encode_struct(&self, ctx: &mut VariantToBinaryContext, ds: &mut ByteStream,
+    fn encode_struct(&self, ctx: &mut VariantToBinaryContext, ds: &mut Bytes,
                      struct_def: &Struct, object: &JsonValue)
                      -> Result<(), ABIError> {
         // we want to serialize a struct...
@@ -463,13 +463,12 @@ impl ABI {
     where
         T: Into<TypeName<'a>>
     {
-        let mut ds = ByteStream::from(bytes);
-        self.decode_variant_(&mut ds, typename.into())
+        self.decode_variant_(&mut bytes.view(), typename.into())
     }
 
 
     #[inline]
-    pub fn decode_variant<'a, T>(&self, ds: &mut ByteStream, typename: T) -> Result<JsonValue, ABIError>
+    pub fn decode_variant<'a, T>(&self, ds: &mut ByteStreamView, typename: T) -> Result<JsonValue, ABIError>
     where
         T: Into<TypeName<'a>>
     {
@@ -477,7 +476,7 @@ impl ABI {
     }
 
     #[allow(clippy::collapsible_else_if)]
-    fn decode_variant_(&self, ds: &mut ByteStream, typename: TypeName) -> Result<JsonValue, ABIError> {
+    fn decode_variant_(&self, ds: &mut ByteStreamView, typename: TypeName) -> Result<JsonValue, ABIError> {
         let rtype = self.resolve_type(typename);
         let ftype = rtype.fundamental_type();
 
@@ -550,7 +549,7 @@ impl ABI {
         })
     }
 
-    fn decode_struct(&self, ds: &mut ByteStream, struct_def: &Struct) -> Result<JsonValue, ABIError> {
+    fn decode_struct(&self, ds: &mut ByteStreamView, struct_def: &Struct) -> Result<JsonValue, ABIError> {
         debug!(r#"reading struct with name "{}" and base "{}""#, struct_def.name, struct_def.base);
 
         let mut result: JsonMap<String, JsonValue> = JsonMap::new();
@@ -596,12 +595,12 @@ impl ABI {
     }
 }
 
-fn read_value(stream: &mut ByteStream, type_: AntelopeType, what: &str) ->  Result<JsonValue, ABIError> {
+fn read_value(stream: &mut ByteStreamView, type_: AntelopeType, what: &str) ->  Result<JsonValue, ABIError> {
     Ok(AntelopeValue::from_bin(type_, stream)
        .context(DeserializeSnafu { what })?.to_variant())
 }
 
-fn decode_usize(stream: &mut ByteStream, what: &str) -> Result<usize, ABIError> {
+fn decode_usize(stream: &mut ByteStreamView, what: &str) -> Result<usize, ABIError> {
     let n = VarUint32::from_bin(stream).context(DeserializeSnafu { what })?;
     Ok(n.into())
 }

--- a/kudu/src/abiserializable.rs
+++ b/kudu/src/abiserializable.rs
@@ -8,7 +8,7 @@ use snafu::{Snafu, ResultExt};
 use kudu_macros::with_location;
 
 use crate::{
-    ByteStream, StreamError, ABIError,
+    ByteStreamView, StreamError, ABIError,
     types::*,
     impl_auto_error_conversion,
 };
@@ -54,31 +54,30 @@ impl_auto_error_conversion!(InvalidAsset, SerializeError, InvalidAssetSnafu);
 impl_auto_error_conversion!(InvalidCryptoData, SerializeError, InvalidCryptoDataSnafu);
 
 
-/// Define methods required to (de)serialize a struct to a [`ByteStream`]
+/// Define methods required to (de)serialize a struct to a [`Bytes`] (from a `ByteStreamView`)
 pub trait ABISerializable {
-    fn to_bin(&self, stream: &mut ByteStream);
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError>
+    fn to_bin(&self, stream: &mut Bytes);
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError>
     where
         Self: Sized;
 }
 
 /// Serialize a `ABISerializable` type to binary data.
 pub fn to_bin<T: ABISerializable>(value: &T) -> Bytes {
-    let mut s = ByteStream::new();
+    let mut s = Bytes::new();
     value.to_bin(&mut s);
-    Bytes(s.into_bytes())
+    s
 }
 
 /// Return the hex representation of the binary serialization of a `ABISerializable` type.
 pub fn to_hex<T: ABISerializable>(value: &T) -> String {
-    let mut s = ByteStream::new();
+    let mut s = Bytes::new();
     value.to_bin(&mut s);
-    s.hex_data()
+    s.to_hex()
 }
 
-// FIXME: this makes an unnecessary copy
 pub fn from_bin<T: ABISerializable>(bin: impl AsRef<[u8]>) -> Result<T, SerializeError> {
-    let mut s = ByteStream::from(bin.as_ref().to_vec());
+    let mut s = ByteStreamView::from(bin.as_ref());
     T::from_bin(&mut s)
 }
 
@@ -90,11 +89,11 @@ macro_rules! impl_pod_serialization {
     ($typ:ty, $size:literal) => {
         impl ABISerializable for $typ {
             #[inline]
-            fn to_bin(&self, stream: &mut ByteStream) {
+            fn to_bin(&self, stream: &mut Bytes) {
                 stream.write_bytes(cast_ref::<$typ, [u8; $size]>(self))
             }
             #[inline]
-            fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+            fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
                 Ok(pod_read_unaligned(stream.read_bytes($size)?))
             }
         }
@@ -105,11 +104,11 @@ macro_rules! impl_wrapped_serialization {
     ($typ:ty, $inner:ty) => {
         impl ABISerializable for $typ {
             #[inline]
-            fn to_bin(&self, stream: &mut ByteStream) {
+            fn to_bin(&self, stream: &mut Bytes) {
                 <$inner>::from(*self).to_bin(stream)
             }
             #[inline]
-            fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+            fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
                 Ok(<$typ>::from(<$inner>::from_bin(stream)?))
             }
         }
@@ -120,11 +119,11 @@ macro_rules! impl_array_serialization {
     ($typ:ty, $size:literal) => {
         impl ABISerializable for $typ {
             #[inline]
-            fn to_bin(&self, stream: &mut ByteStream) {
+            fn to_bin(&self, stream: &mut Bytes) {
                 stream.write_bytes(&self.0[..])
             }
             #[inline]
-            fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+            fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
                 let arr: [u8; $size] = stream.read_bytes($size)?.try_into().unwrap();  // safe unwrap
                 Ok(<$typ>::from(arr))
             }
@@ -139,14 +138,14 @@ macro_rules! impl_array_serialization {
 
 impl ABISerializable for bool {
     #[inline]
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         stream.write_byte(match *self {
             true => 1u8,
             false => 0u8,
         })
     }
     #[inline]
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         match stream.read_byte()? {
             1 => Ok(true),
             0 => Ok(false),
@@ -157,11 +156,11 @@ impl ABISerializable for bool {
 
 impl ABISerializable for i8 {
     #[inline]
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         stream.write_byte(*self as u8)
     }
     #[inline]
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         Ok(stream.read_byte()? as i8)
     }
 }
@@ -173,11 +172,11 @@ impl_pod_serialization!(i128, 16);
 
 impl ABISerializable for u8 {
     #[inline]
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         stream.write_byte(*self)
     }
     #[inline]
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         Ok(stream.read_byte()?)
     }
 }
@@ -192,33 +191,33 @@ impl_pod_serialization!(f64, 8);
 
 impl ABISerializable for Float128 {
     #[inline]
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         stream.write_bytes(self.to_bin_repr())
     }
     #[inline]
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         Ok(Float128::from_bin_repr(stream.read_bytes(16)?.try_into().unwrap()))  // safe unwrap
     }
 }
 
 impl ABISerializable for VarInt32 {
     #[inline]
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         stream.write_var_i32(i32::from(*self))
     }
     #[inline]
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         Ok(stream.read_var_i32()?.into())
     }
 }
 
 impl ABISerializable for VarUint32 {
     #[inline]
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         stream.write_var_u32(u32::from(*self))
     }
     #[inline]
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         Ok(stream.read_var_u32()?.into())
     }
 }
@@ -229,11 +228,11 @@ impl ABISerializable for VarUint32 {
 // -----------------------------------------------------------------------------
 
 impl ABISerializable for Bytes {
-    fn to_bin(&self, stream: &mut ByteStream) {
-        stream.write_var_u32(self.0.len() as u32);
-        stream.write_bytes(&self.0[..]);
+    fn to_bin(&self, stream: &mut Bytes) {
+        stream.write_var_u32(self.as_bytes().len() as u32);
+        stream.write_bytes(self.as_bytes());
     }
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         let len = stream.read_var_u32()? as usize;
         Ok(Bytes::from(stream.read_bytes(len)?))
     }
@@ -241,21 +240,21 @@ impl ABISerializable for Bytes {
 
 // convenience implementation to avoid allocating when encoding a &[u8]
 impl ABISerializable for &[u8] {
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         stream.write_var_u32(self.len() as u32);
         stream.write_bytes(self);
     }
-    fn from_bin(_stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(_stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         unimplemented!();
     }
 }
 
 impl ABISerializable for String {
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         stream.write_var_u32(self.len() as u32);
         stream.write_bytes(self.as_bytes());
     }
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         let len = stream.read_var_u32()? as usize;
         from_utf8(stream.read_bytes(len)?).context(Utf8Snafu).map(|s| s.to_owned())
     }
@@ -263,11 +262,11 @@ impl ABISerializable for String {
 
 // convenience implementation to avoid allocating encoding a &str
 impl ABISerializable for &str {
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         stream.write_var_u32(self.len() as u32);
         stream.write_bytes(self.as_bytes());
     }
-    fn from_bin(_stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(_stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         unimplemented!()
     }
 }
@@ -297,12 +296,12 @@ impl_array_serialization!(Checksum512, 64);
 
 impl ABISerializable for Name {
     #[inline]
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         self.as_u64().to_bin(stream)
     }
 
     #[inline]
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         let n = u64::from_bin(stream)?;
         Ok(Name::from_u64(n))
     }
@@ -310,12 +309,12 @@ impl ABISerializable for Name {
 
 impl ABISerializable for Symbol {
     #[inline]
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         self.as_u64().to_bin(stream)
     }
 
     #[inline]
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         let n = u64::from_bin(stream)?;
         Ok(Symbol::from_u64(n)?)
     }
@@ -323,24 +322,24 @@ impl ABISerializable for Symbol {
 
 impl ABISerializable for SymbolCode {
     #[inline]
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         self.as_u64().to_bin(stream)
     }
 
     #[inline]
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         let n = u64::from_bin(stream)?;
         Ok(SymbolCode::from_u64(n))
     }
 }
 
 impl ABISerializable for Asset {
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         self.amount().to_bin(stream);
         self.symbol().to_bin(stream);
     }
 
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         let amount = i64::from_bin(stream)?;
         let symbol = Symbol::from_bin(stream)?;
         Ok(Asset::new(amount, symbol)?)
@@ -348,12 +347,12 @@ impl ABISerializable for Asset {
 }
 
 impl ABISerializable for ExtendedAsset {
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         self.quantity.to_bin(stream);
         self.contract.to_bin(stream);
     }
 
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         let quantity = Asset::from_bin(stream)?;
         let contract = Name::from_bin(stream)?;
         Ok(ExtendedAsset { quantity, contract })
@@ -361,12 +360,12 @@ impl ABISerializable for ExtendedAsset {
 }
 
 impl<T: CryptoDataType, const DATA_SIZE: usize> ABISerializable for CryptoData<T, DATA_SIZE> {
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         stream.write_byte(self.key_type().index());
         stream.write_bytes(self.data());
     }
 
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         let key_type = KeyType::from_index(stream.read_byte()?)?;
         let data = stream.read_bytes(DATA_SIZE)?.try_into().unwrap();  // safe unwrap
         Ok(Self::with_key_type(key_type, data))
@@ -375,12 +374,12 @@ impl<T: CryptoDataType, const DATA_SIZE: usize> ABISerializable for CryptoData<T
 
 // this, coupled with the blanket impl for Vec, gives us the impl for the `Extensions` type
 impl ABISerializable for (u16, Bytes) {
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         self.0.to_bin(stream);
         self.1.to_bin(stream);
     }
 
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         let id = u16::from_bin(stream)?;
         let data = Bytes::from_bin(stream)?;
         Ok((id, data))
@@ -399,14 +398,14 @@ impl ABISerializable for (u16, Bytes) {
 // -----------------------------------------------------------------------------
 
 impl<T: ABISerializable + Debug, const N: usize> ABISerializable for [T; N] {
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         stream.write_var_u32(self.len() as u32);
         for elem in self {
             elem.to_bin(stream);
         }
     }
 
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         let len: u32 = VarUint32::from_bin(stream)?.into();
         let mut result = Vec::with_capacity(len as usize);
         for _ in 0..len {
@@ -427,14 +426,14 @@ impl<T: ABISerializable + Debug, const N: usize> ABISerializable for [T; N] {
 //  - optimized impl for Vec<u8>, but we have to manually implement
 //    (possibly with the help of a macro) all the other needed types
 impl<T: ABISerializable> ABISerializable for Vec<T> {
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         stream.write_var_u32(self.len() as u32);
         for elem in self {
             elem.to_bin(stream);
         }
     }
 
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         let len: u32 = VarUint32::from_bin(stream)?.into();
         let mut result = Vec::with_capacity(len as usize);
         for _ in 0..len {
@@ -449,7 +448,7 @@ impl<T: ABISerializable> ABISerializable for Vec<T> {
 // -----------------------------------------------------------------------------
 
 impl<T: ABISerializable> ABISerializable for Option<T> {
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         match self {
             Some(v) => {
                 true.to_bin(stream);
@@ -461,7 +460,7 @@ impl<T: ABISerializable> ABISerializable for Option<T> {
         }
     }
 
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         Ok(match bool::from_bin(stream)? {
             true => Some(T::from_bin(stream)?),
             false => None,
@@ -474,11 +473,11 @@ impl<T: ABISerializable> ABISerializable for Option<T> {
 // -----------------------------------------------------------------------------
 
 impl<T: ABISerializable> ABISerializable for Box<T> {
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         self.as_ref().to_bin(stream);
     }
 
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         Ok(Box::new(T::from_bin(stream)?))
    }
 }
@@ -488,14 +487,14 @@ impl<T: ABISerializable> ABISerializable for Box<T> {
 // -----------------------------------------------------------------------------
 
 impl<T: ABISerializable + Ord> ABISerializable for BTreeSet<T> {
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         stream.write_var_u32(self.len() as u32);
         for v in self {
             v.to_bin(stream);
         }
     }
 
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         let len: u32 = VarUint32::from_bin(stream)?.into();
         let mut result = BTreeSet::new();
         for _ in 0..len {
@@ -514,7 +513,7 @@ where
     K: ABISerializable + Ord,
     V: ABISerializable,
 {
-    fn to_bin(&self, stream: &mut ByteStream) {
+    fn to_bin(&self, stream: &mut Bytes) {
         stream.write_var_u32(self.len() as u32);
         for (k, v) in self {
             k.to_bin(stream);
@@ -522,7 +521,7 @@ where
         }
     }
 
-    fn from_bin(stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    fn from_bin(stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         let len: u32 = VarUint32::from_bin(stream)?.into();
         let mut result = BTreeMap::new();
         for _ in 0..len {

--- a/kudu/src/bin/kuduconv.rs
+++ b/kudu/src/bin/kuduconv.rs
@@ -5,7 +5,7 @@ use clap::{Parser, Subcommand};
 use color_eyre::{Result, eyre::{eyre, OptionExt, WrapErr}};
 use serde_json::Value;
 
-use kudu::{abi, ByteStream, ABI};
+use kudu::{abi, Bytes, ABI};
 
 
 #[derive(Parser)]
@@ -93,27 +93,28 @@ pub fn main() -> Result<()> {
             let abi = get_abi(abi, &typename)?;
 
             // create a byte stream for storing the bin representation
-            let mut ds = ByteStream::new();
+            let mut ds = Bytes::new();
 
             // perform the json->hex conversion
             let v: Value = json.parse()?;
             abi.encode_variant(&mut ds, &typename,  &v)?;
 
-            println!("{}", ds.hex_data());
+            println!("{}", ds.to_hex());
         }
 
         Commands::FromHex { abi, typename, hex } => {
             let abi = get_abi(abi, &typename)?;
 
             // create a byte stream from the given hex representation
-            let mut bin = ByteStream::from_hex(&hex)?;
+            let bin = Bytes::from_hex(&hex)?;
+            let mut view = bin.view();
 
             // perform the hex->json conversion
-            let v = abi.decode_variant(&mut bin, &typename)?;
+            let v = abi.decode_variant(&mut view, &typename)?;
 
-            if !bin.leftover().is_empty() {
+            if !view.leftover().is_empty() {
                 return Err(eyre!("Trailing input, {} bytes haven't been consumed. Decoded object: {:?}",
-                                 bin.leftover().len(), &v));
+                                 view.leftover().len(), &v));
             }
 
             println!("{}", v);

--- a/kudu/src/bytestream.rs
+++ b/kudu/src/bytestream.rs
@@ -1,11 +1,12 @@
 use std::num::ParseIntError;
 
 use hex;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use snafu::{ensure, Snafu};
 use tracing::trace;
 
 use kudu_macros::with_location;
-use crate::Bytes;
+
 
 #[with_location]
 #[derive(Debug, Snafu)]
@@ -25,16 +26,100 @@ pub enum StreamError {
 
 
 /// Provide access to a byte stream along with a cursor to read into it.
+/// This is a non-owning type, the string type equivalent would be `&str`.
 ///
 /// This is different that both `std::io::Read`/`std::io::Write` and the `bytes`
 /// crate as this is supposed to be used for reading from files/streams that have
 /// an end, so the `read` operation is fallible, but when writing we assume everything
-/// is fine so the `write` operation is infallible.
+/// is fine (we usually write into memory) so the `write` operation is infallible.
+#[derive(Default)]
+pub struct ByteStreamView<'a> {
+    data: &'a [u8],
+
+    read_pos: usize,
+}
+
+impl<'a> From<&'a [u8]> for ByteStreamView<'a> {
+    fn from(data: &'a [u8]) -> Self {
+        ByteStreamView { data, read_pos: 0 }
+    }
+}
+
+impl<'a> From<&'a Vec<u8>> for ByteStreamView<'a> {
+    fn from(data: &'a Vec<u8>) -> Self {
+        ByteStreamView { data: data.as_ref(), read_pos: 0 }
+    }
+}
+
+impl<'a> ByteStreamView<'a> {
+    pub fn leftover(&self) -> &[u8] {
+        &self.data[self.read_pos..]
+    }
+
+    pub fn read_byte(&mut self) -> Result<u8, StreamError> {
+        let pos = self.read_pos;
+        ensure!(pos != self.data.len(), EndedSnafu { wanted: 1_usize, available: 0_usize });
+
+        trace!("read 1 byte - hex: {}", hex::encode(&self.data[pos..pos + 1]));
+        self.read_pos += 1;
+        Ok(self.data[pos])
+    }
+
+    pub fn read_bytes(&mut self, n: usize) -> Result<&[u8], StreamError> {
+        let available = self.data.len() - self.read_pos;
+        ensure!(n <= available, EndedSnafu { wanted: n, available });
+
+        let result = &self.data[self.read_pos..self.read_pos + n];
+        trace!("read {n} bytes - hex: {}", hex::encode(result));
+        self.read_pos += n;
+        Ok(result)
+    }
+
+    pub fn read_var_u32(&mut self) -> Result<u32, StreamError> {
+        let mut offset = 0;
+        let mut result = 0;
+        loop {
+            let byte = self.read_byte()?;
+            result |= (byte as u32 & 0x7F) << offset;
+            offset += 7;
+            if (byte & 0x80) == 0 { break; }
+
+            ensure!(offset < 32, InvalidVarIntSnafu);
+        }
+        Ok(result)
+    }
+
+    pub fn read_var_i32(&mut self) -> Result<i32, StreamError> {
+        let n = self.read_var_u32()?;
+        Ok(match n & 1 {
+            0 => n >> 1,
+            _ => ((!n) >> 1) | 0x8000_0000,
+        } as i32)
+    }
+}
+
+// FIXME: rename ByteStream to ByteBuffer
+//        actually: use Bytes instead of ByteStream for writing data, and only
+//                  ByteStreamView (rename to ByteStream then) for reading
+
+/// Provide access to a byte stream along with a cursor to read into it.
+/// This is an owning type, the string type equivalent would be `String`.
+///
+/// This is different that both `std::io::Read`/`std::io::Write` and the `bytes`
+/// crate as this is supposed to be used for reading from files/streams that have
+/// an end, so the `read` operation is fallible, but when writing we assume everything
+/// is fine (we usually write into memory) so the `write` operation is infallible.
 #[derive(Default)]
 pub struct ByteStream {
     data: Vec<u8>,
 
     read_pos: usize,
+}
+
+impl<'a> From<&'a ByteStream> for ByteStreamView<'a> {
+    fn from(stream: &'a ByteStream) -> ByteStreamView<'a> {
+        ByteStreamView { data: &stream.data, read_pos: stream.read_pos }
+    }
 }
 
 impl From<ByteStream> for Vec<u8> {
@@ -68,58 +153,45 @@ impl ByteStream {
             read_pos: 0,
         }
     }
+}
 
-    pub fn from_hex<T: AsRef<[u8]>>(data: T) -> Result<Self, hex::FromHexError> {
-        Ok(ByteStream::from(Bytes::from_hex(data)?))
+
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct Bytes(Vec<u8>);
+
+impl Bytes {
+    pub fn new() -> Self { Bytes(vec![]) }
+
+    pub fn from_hex<T: AsRef<[u8]>>(data: T) -> Result<Bytes, hex::FromHexError> {
+        Ok(Bytes(hex::decode(data)?))
     }
 
-    pub fn data(&self) -> &[u8] {
-        self.data.as_slice()
-    }
-
-    pub fn into_bytes(self) -> Vec<u8> {
-        self.data
+    pub fn to_hex(&self) -> String {
+        hex::encode(&self.0)
     }
 
     pub fn clear(&mut self) {
-        self.data.clear();
+        self.0.clear()
     }
 
-    pub fn hex_data(&self) -> String {
-        hex::encode(&self.data)
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
     }
 
-    pub fn leftover(&self) -> &[u8] {
-        &self.data[self.read_pos..]
+    pub fn view<'a>(&'a self) -> ByteStreamView<'a> {
+        self.into()
     }
 
-    pub fn read_byte(&mut self) -> Result<u8, StreamError> {
-        let pos = self.read_pos;
-        ensure!(pos != self.data.len(), EndedSnafu { wanted: 1_usize, available: 0_usize });
-
-        trace!("read 1 byte - hex: {}", hex::encode(&self.data[pos..pos + 1]));
-        self.read_pos += 1;
-        Ok(self.data[pos])
-    }
-
-    pub fn read_bytes(&mut self, n: usize) -> Result<&[u8], StreamError> {
-        let available = self.data.len() - self.read_pos;
-        ensure!(n <= available, EndedSnafu { wanted: n, available });
-
-        let result = &self.data[self.read_pos..self.read_pos + n];
-        trace!("read {n} bytes - hex: {}", hex::encode(result));
-        self.read_pos += n;
-        Ok(result)
-    }
 
     #[inline]
     pub fn write_byte(&mut self, byte: u8) {
-        self.data.push(byte)
+        self.0.push(byte)
     }
 
     #[inline]
     pub fn write_bytes(&mut self, bytes: &[u8]) {
-        self.data.extend_from_slice(bytes)
+        self.0.extend_from_slice(bytes)
     }
 
     pub fn write_var_u32(&mut self, n: u32) {
@@ -141,26 +213,69 @@ impl ByteStream {
         self.write_var_u32(unsigned)
     }
 
-    pub fn read_var_u32(&mut self) -> Result<u32, StreamError> {
-        let mut offset = 0;
-        let mut result = 0;
-        loop {
-            let byte = self.read_byte()?;
-            result |= (byte as u32 & 0x7F) << offset;
-            offset += 7;
-            if (byte & 0x80) == 0 { break; }
+}
 
-            ensure!(offset < 32, InvalidVarIntSnafu);
-        }
-        Ok(result)
+impl From<Vec<u8>> for Bytes {
+    fn from(v: Vec<u8>) -> Bytes {
+        Bytes(v)
     }
+}
 
-    pub fn read_var_i32(&mut self) -> Result<i32, StreamError> {
-        let n = self.read_var_u32()?;
-        Ok(match n & 1 {
-            0 => n >> 1,
-            _ => ((!n) >> 1) | 0x8000_0000,
-        } as i32)
+impl From<&[u8]> for Bytes {
+    fn from(s: &[u8]) -> Bytes {
+        Bytes(s.to_vec())
     }
+}
 
+impl<const N: usize> From<&[u8; N]> for Bytes {
+    fn from(s: &[u8; N]) -> Bytes {
+        Bytes(s.to_vec())
+    }
+}
+
+// This should probably be using Bytes::from_hex if we define it, however this
+// conversion is probably prone to error so we don't define it for now unless
+// a good reason comes up that we should
+// impl From<&str> for Bytes {
+//     fn from(s: &str) -> Bytes {
+//         Bytes(s.as_bytes().to_vec())
+//     }
+// }
+
+impl From<Bytes> for Vec<u8> {
+    fn from(b: Bytes) -> Vec<u8> {
+        b.0
+    }
+}
+
+impl AsRef<[u8]> for Bytes {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<'a> From<&'a Bytes> for ByteStreamView<'a> {
+    fn from(data: &'a Bytes) -> ByteStreamView<'a> {
+        ByteStreamView { data: data.as_bytes(), read_pos: 0 }
+    }
+}
+
+
+impl Serialize for Bytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer
+    {
+        self.to_hex().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Bytes {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let hex_repr: &str = <&str>::deserialize(deserializer)?;
+        Bytes::from_hex(hex_repr).map_err(|e| de::Error::custom(e.to_string()))
+    }
 }

--- a/kudu/src/chain.rs
+++ b/kudu/src/chain.rs
@@ -89,20 +89,25 @@ pub struct Transfer {
 
 
 // TODO: move this to api.rs (or not?)
+pub const DEBUG: usize = 0;
+pub const WARN: usize = 1;
 
-// TODO: make tracing level configurable so we can use it for both success and error logging
-pub fn nodeos_log(response: &JsonValue, console_output: &[String]) {
+pub fn nodeos_log<const N: usize>(response: &JsonValue, console_output: &[String]) {
     // this is a separate function (instead of inline) so it shows that the logs come from nodeos
-    if !console_output.is_empty() {
-        let tx_id = response["transaction_id"].as_str().unwrap();
-        debug!("Console output for tx: {}", tx_id);
-    }
+    if console_output.is_empty() { return; }
+
+    let tx_id = response["transaction_id"].as_str().unwrap();
+    if      N == DEBUG { debug!("Console output for tx: {}", tx_id); }
+    else if N == WARN  {  warn!("Console output for tx: {}", tx_id); }
+
     for output in console_output {
         for line in output.lines() {
-            debug!(line);
+            if      N == DEBUG { debug!(line); }
+            else if N == WARN  { warn!(line);  }
         }
     }
 }
+
 
 /// Parse a full JSON transaction trace and return the relevant message lines
 /// WARNING: this panics if the trace is malformed
@@ -143,18 +148,13 @@ pub fn parse_trace(response: &JsonValue) -> Result<Vec<String>, Vec<String>> {
 /// Log the results of a sent transaction.
 /// Return a `TransactionError` if there was an issue with the transaction.
 pub fn log_tx_trace(response: &JsonValue) -> Result<(), TransactionError> {
-    // TODO: use `nodeos_log()` instead
     match parse_trace(response) {
         Ok(lines) => {
-            for l in lines.iter() {
-                debug!("{}", l);
-            }
+            nodeos_log::<DEBUG>(response, &lines);
             Ok(())
         },
         Err(lines) => {
-            for l in lines.iter() {
-                warn!("{}", l);
-            }
+            nodeos_log::<WARN>(response, &lines);
             Err(TransactionError::NodeosError { message: lines.join("\n") })
         },
     }

--- a/kudu/src/chain/action.rs
+++ b/kudu/src/chain/action.rs
@@ -27,6 +27,9 @@ pub struct PermissionLevel {
     pub permission: PermissionName,
 }
 
+// NOTE: we need this trait and cannot use `impl From<T> for Vec<PermissionLevel>`
+//       if T is not part of this package (because of the orphan rule)
+// NOTE: we could fix it by defining a new type PermissionVec = Vec<PermissionLevel>
 pub trait IntoPermissionVec {
     fn into_permission_vec(self) -> Vec<PermissionLevel>;
 }

--- a/kudu/src/chain/action.rs
+++ b/kudu/src/chain/action.rs
@@ -9,7 +9,7 @@ use crate::{
     AccountName, ActionName, Contract,
     PermissionName, Name, ABISerializable,
     abiserializable::to_bin, Bytes, JsonValue,
-    ByteStream, ABI, ABIError, InvalidName,
+    ByteStreamView, ABI, ABIError, InvalidName,
     abi, with_location, impl_auto_error_conversion,
 };
 
@@ -157,9 +157,9 @@ impl Action {
             // otherwise, we need an ABI to encode the data into a binary string
             let data = &action["data"];
             let abi = abi::registry::get_abi(account)?;
-            let mut ds = ByteStream::new();
+            let mut ds = Bytes::new();
             abi.encode_variant(&mut ds, action_name, data)?;
-            ds.into()
+            ds
         };
 
         Ok(Action {
@@ -182,16 +182,15 @@ impl Action {
     }
 
     pub fn decode_data_with_abi(&self, abi: &ABI) -> Result<JsonValue, ABIError> {
-        // FIXME: this .clone() is unnecessary once we fix deserializing from bytestream
-        let mut ds = ByteStream::from(self.data.clone());
+        let mut ds = ByteStreamView::from(&self.data);
         abi.decode_variant(&mut ds, &self.name.to_string())
     }
 
     pub fn with_data(mut self, value: &JsonValue) -> Result<Self, ActionError> {
-        let mut ds = ByteStream::new();
+        let mut ds = Bytes::new();
         let abi = abi::registry::get_abi(&self.account.to_string())?;
         abi.encode_variant(&mut ds, &self.name.to_string(), value)?;
-        self.data = ds.into();
+        self.data = ds;
         Ok(self)
     }
 

--- a/kudu/src/chain/transaction.rs
+++ b/kudu/src/chain/transaction.rs
@@ -11,7 +11,7 @@ use sha2::{Sha256, Digest};
 use snafu::{ResultExt, Snafu, ensure};
 
 use crate::{
-    ABISerializable, APIClient, Action, ActionError, BlockId, ByteStream, Bytes, ChainId,
+    ABISerializable, APIClient, Action, ActionError, BlockId, Bytes, ChainId,
     Checksum256, Extensions, JsonValue, PrivateKey, Signature, TimePointSec, TransactionId,
     VarUint32,
     api::HttpError,
@@ -120,9 +120,9 @@ impl Transaction {
         }
     }
     pub fn id(&self) -> TransactionId {
-        let mut ds = ByteStream::new();
-        self.to_bin(&mut ds);
-        let hash = sha2::Sha256::digest(ds.data());
+        let mut data = Bytes::new();
+        self.to_bin(&mut data);
+        let hash = sha2::Sha256::digest(&data);
         let r: [u8; 32] = hash.into();
         r.into()
     }
@@ -156,9 +156,9 @@ impl Transaction {
             None => UnlinkedTransactionSnafu { message: "you need a chain ID to be set to compute the tx digest".to_string() }.fail()?,
         }
 
-        let mut ds = ByteStream::new();
+        let mut ds = Bytes::new();
         self.to_bin(&mut ds);
-        hasher.update(ds.data());
+        hasher.update(&ds);
 
         if !context_free_data.is_empty() {
             hasher.update(Sha256::digest(context_free_data));
@@ -227,7 +227,7 @@ impl Transaction {
 // TODO: we implement this manually as we don't have a way yet to ignore fields using the derive macro
 // TODO: implement this, using #[serde(skip)] to decide whether to skip fields
 impl kudu::ABISerializable for Transaction {
-    fn to_bin(&self, s: &mut kudu::ByteStream) {
+    fn to_bin(&self, s: &mut kudu::Bytes) {
         // transaction header
         self.expiration.to_bin(s);
         self.ref_block_num.to_bin(s);
@@ -240,7 +240,7 @@ impl kudu::ABISerializable for Transaction {
         self.actions.to_bin(s);
         self.transaction_extensions.to_bin(s);
     }
-    fn from_bin(s: &mut kudu::ByteStream) -> ::core::result::Result<Self, kudu::SerializeError> {
+    fn from_bin(s: &mut kudu::ByteStreamView) -> ::core::result::Result<Self, kudu::SerializeError> {
         Ok(Self {
             // transaction header
             expiration: TimePointSec::from_bin(s)?,
@@ -302,9 +302,9 @@ impl Serialize for SignedTransaction {
         map.serialize_entry("compression", &self.compression)?;
         map.serialize_entry("packed_content_free_data", &self.packed_content_free_data)?;
 
-        let mut s = ByteStream::new();
+        let mut s = Bytes::new();
         self.tx.to_bin(&mut s);
-        map.serialize_entry("packed_trx", &s.hex_data())?;
+        map.serialize_entry("packed_trx", &s.to_hex())?;
 
         map.end()
     }

--- a/kudu/src/lib.rs
+++ b/kudu/src/lib.rs
@@ -131,7 +131,7 @@ pub use abi::{ABI, ABIError, ABIDefinition, TypeName};
 pub mod abiserializable;
 pub mod bytestream;
 
-pub use bytestream::{ByteStream, StreamError};
+pub use bytestream::{ByteStreamView, StreamError};
 pub use abiserializable::{ABISerializable, SerializeError, to_bin, to_hex, from_bin};
 
 /// Add a `location` field to all variants of a `Snafu` error enum

--- a/kudu/src/types.rs
+++ b/kudu/src/types.rs
@@ -58,71 +58,7 @@ pub use float128::Float128;
 //     Bytes and String types
 // -----------------------------------------------------------------------------
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
-pub struct Bytes(pub Vec<u8>);
-
-impl Bytes {
-    pub fn new() -> Self { Bytes(vec![]) }
-    pub fn from_hex<T: AsRef<[u8]>>(data: T) -> Result<Bytes, FromHexError> {
-        Ok(Bytes(hex::decode(data)?))
-    }
-    pub fn to_hex(&self) -> String {
-        hex::encode(&self.0)
-    }
-}
-
-impl From<Vec<u8>> for Bytes {
-    fn from(v: Vec<u8>) -> Bytes {
-        Bytes(v)
-    }
-}
-
-impl From<&[u8]> for Bytes {
-    fn from(s: &[u8]) -> Bytes {
-        Bytes(s.to_vec())
-    }
-}
-
-// This should probably be using Bytes::from_hex if we define it, however this
-// conversion is probably prone to error so we don't define it for now unless
-// a good reason comes up that we should
-// impl From<&str> for Bytes {
-//     fn from(s: &str) -> Bytes {
-//         Bytes(s.as_bytes().to_vec())
-//     }
-// }
-
-impl From<Bytes> for Vec<u8> {
-    fn from(b: Bytes) -> Vec<u8> {
-        b.0
-    }
-}
-
-impl AsRef<[u8]> for Bytes {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl Serialize for Bytes {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer
-    {
-        self.to_hex().serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for Bytes {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let hex_repr: &str = <&str>::deserialize(deserializer)?;
-        Bytes::from_hex(hex_repr).map_err(|e| de::Error::custom(e.to_string()))
-    }
-}
-
+pub use crate::bytestream::Bytes;
 pub type String = std::string::String;
 
 

--- a/kudu/src/types/antelopevalue.rs
+++ b/kudu/src/types/antelopevalue.rs
@@ -13,7 +13,7 @@ use tracing::instrument;
 use kudu_macros::with_location;
 
 use crate::{
-    json, JsonError, JsonValue, ByteStream, SerializeError, ABISerializable,
+    json, JsonError, JsonValue, ByteStreamView, SerializeError, ABISerializable,
     impl_auto_error_conversion,
 };
 
@@ -247,7 +247,7 @@ impl AntelopeValue {
         })
     }
 
-    pub fn to_bin(&self, stream: &mut ByteStream) {
+    pub fn to_bin(&self, stream: &mut Bytes) {
         match self {
             Self::Bool(b) => b.to_bin(stream),
             Self::Int8(n) => n.to_bin(stream),
@@ -285,7 +285,7 @@ impl AntelopeValue {
     }
 
     #[instrument(skip(stream))]
-    pub fn from_bin(typename: AntelopeType, stream: &mut ByteStream) -> Result<Self, SerializeError> {
+    pub fn from_bin(typename: AntelopeType, stream: &mut ByteStreamView) -> Result<Self, SerializeError> {
         Ok(match typename {
             AntelopeType::Bool => Self::Bool(bool::from_bin(stream)?),
             AntelopeType::Int8 => Self::Int8(i8::from_bin(stream)?),

--- a/kudu/src/types/asset.rs
+++ b/kudu/src/types/asset.rs
@@ -24,7 +24,7 @@ pub enum InvalidAsset {
     #[snafu(display("amount overflow for: {amount}"))]
     AmountOverflow { amount: String },
 
-    #[snafu(display("ammount out of range, max is 2^62-1"))]
+    #[snafu(display("amount out of range, max is 2^62-1"))]
     AmountOutOfRange,
 
     #[snafu(display("could not parse symbol from asset string"))]

--- a/kudu/src/types/time.rs
+++ b/kudu/src/types/time.rs
@@ -16,21 +16,21 @@ use crate::config;
 #[derive(Debug, Snafu)]
 pub enum InvalidTimePoint {
     #[snafu(display("Invalid year-month-day: {year}-{month}-{day}"))]
-    YMD {
+    Ymd {
         year: i32,
         month: u32,
         day: u32,
     },
 
     #[snafu(display("Invalid hour:minute:second: {hour}:{min}:{sec}"))]
-    HMS {
+    Hms {
         hour: u32,
         min: u32,
         sec: u32,
     },
 
     #[snafu(display("Invalid hour:minute:second.milli: {hour}:{min}:{sec}.{milli}"))]
-    HMSMilli {
+    HmsMilli {
         hour: u32,
         min: u32,
         sec: u32,
@@ -38,7 +38,7 @@ pub enum InvalidTimePoint {
     },
 
     #[snafu(display("Invalid hour:minute:second.micro: {hour}:{min}:{sec}.{micro}"))]
-    HMSMicro {
+    HmsMicro {
         hour: u32,
         min: u32,
         sec: u32,
@@ -131,14 +131,14 @@ pub struct TimePoint(i64);
 impl TimePoint {
     pub fn new(year: i32, month: u32, day: u32, hour: u32, min: u32, sec: u32, milli: u32) -> Result<Self, InvalidTimePoint> {
         Ok(TimePoint::from_datetime(
-            NaiveDate::from_ymd_opt(year, month, day).context(YMDSnafu { year, month, day })?
-                .and_hms_milli_opt(hour, min, sec, milli).context(HMSMilliSnafu { hour, min, sec, milli })?
+            NaiveDate::from_ymd_opt(year, month, day).context(YmdSnafu { year, month, day })?
+                .and_hms_milli_opt(hour, min, sec, milli).context(HmsMilliSnafu { hour, min, sec, milli })?
                 .and_utc()))
     }
     pub fn from_ymd_hms_micro(year: i32, month: u32, day: u32, hour: u32, min: u32, sec: u32, micro: u32) -> Result<Self, InvalidTimePoint> {
         Ok(TimePoint::from_datetime(
-            NaiveDate::from_ymd_opt(year, month, day).context(YMDSnafu { year, month, day })?
-                .and_hms_micro_opt(hour, min, sec, micro).context(HMSMicroSnafu { hour, min, sec, micro })?
+            NaiveDate::from_ymd_opt(year, month, day).context(YmdSnafu { year, month, day })?
+                .and_hms_micro_opt(hour, min, sec, micro).context(HmsMicroSnafu { hour, min, sec, micro })?
                 .and_utc()))
     }
     pub fn from_datetime(dt: DateTime<Utc>) -> Self {
@@ -176,8 +176,8 @@ pub struct TimePointSec(u32);
 impl TimePointSec {
     pub fn new(year: i32, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> Result<Self, InvalidTimePoint> {
         Ok(TimePointSec::from_datetime(
-            NaiveDate::from_ymd_opt(year, month, day).context(YMDSnafu { year, month, day })?
-                .and_hms_opt(hour, min, sec).context(HMSSnafu { hour, min, sec })?
+            NaiveDate::from_ymd_opt(year, month, day).context(YmdSnafu { year, month, day })?
+                .and_hms_opt(hour, min, sec).context(HmsSnafu { hour, min, sec })?
                 .and_utc()))
     }
     pub fn from_datetime(dt: DateTime<Utc>) -> Self {

--- a/kudu/tests/abieos_test.rs
+++ b/kudu/tests/abieos_test.rs
@@ -12,7 +12,7 @@ use kudu::{
     abi::data::{
         PACKED_TRANSACTION_ABI, TEST_ABI, TOKEN_HEX_ABI, TRANSACTION_ABI
     },
-    ABIDefinition, Asset, Bytes, ByteStream, ExtendedAsset, InvalidValue, JsonValue, Name,
+    ABIDefinition, Asset, Bytes, ByteStreamView, ExtendedAsset, InvalidValue, JsonValue, Name,
     Symbol, SymbolCode, TimePoint, TimePointSec, TypeName, VarInt32, VarUint32, ABI,
     Checksum160, Checksum256, Checksum512, PublicKey, PrivateKey, Signature,
     Transaction, Action, AccountName, Transfer, BlockTimestamp, PackedTransactionV0
@@ -73,7 +73,7 @@ fn transaction_abi() -> &'static ABI {
 // =============================================================================
 
 #[instrument(skip(ds, abi))]
-fn try_encode_stream(ds: &mut ByteStream, abi: &ABI, typename: TypeName, data: &str) -> Result<()> {
+fn try_encode_stream(ds: &mut Bytes, abi: &ABI, typename: TypeName, data: &str) -> Result<()> {
     let value: JsonValue = kudu::json::from_str(data).map_err(InvalidValue::from)?;
     info!("{:?}", &value);
     abi.encode_variant(ds, typename, &value)?;
@@ -81,31 +81,31 @@ fn try_encode_stream(ds: &mut ByteStream, abi: &ABI, typename: TypeName, data: &
 }
 
 fn try_encode(abi: &ABI, typename: &str, data: &str) -> Result<()> {
-    let mut ds = ByteStream::new();
+    let mut ds = Bytes::new();
     try_encode_stream(&mut ds, abi, typename.into(), data)
 }
 
-fn try_decode_stream(ds: &mut ByteStream, abi: &ABI, typename: TypeName) -> Result<JsonValue> {
+fn try_decode_stream(ds: &mut ByteStreamView, abi: &ABI, typename: TypeName) -> Result<JsonValue> {
     let decoded = abi.decode_variant(ds, typename)?;
     assert!(ds.leftover().is_empty(), "leftover data in stream after decoding");
     Ok(decoded)
 }
 
 fn try_decode<T: AsRef<[u8]>>(abi: &ABI, typename: &str, data: T) -> Result<JsonValue> {
-    let mut ds = ByteStream::from(hex::decode(data).map_err(InvalidValue::from)?);
-    try_decode_stream(&mut ds, abi, typename.into())
+    let ds = Bytes::from_hex(data)?;
+    try_decode_stream(&mut ds.view(), abi, typename.into())
 }
 
 /// check roundtrip JSON -> variant -> bin -> variant -> JSON
 #[track_caller]
 fn check_round_trip(abi: &ABI, typename: &str, data: &str, hex: &str, expected: &str) -> Result<()> {
     debug!(r#"==== round-tripping type "{typename}" with value {data}"#);
-    let mut ds = ByteStream::new();
+    let mut ds = Bytes::new();
 
     try_encode_stream(&mut ds, abi, typename.into(), data)?;
-    assert_eq!(ds.hex_data(), hex, "variant to binary");
+    assert_eq!(ds.to_hex(), hex, "variant to binary");
 
-    let decoded = try_decode_stream(&mut ds, abi, typename.into())?;
+    let decoded = try_decode_stream(&mut ds.view(), abi, typename.into())?;
     let repr = kudu::json::to_string(&decoded)?;
 
     assert_eq!(repr, expected, "variant to JSON");
@@ -489,7 +489,7 @@ fn roundtrip_float128() -> Result<()> {
 
     let check_f128 = |hex: &str| {
         let repr = format!(r#""{hex}""#);
-        let value = Float128::from_bin_repr(Bytes::from_hex(hex).unwrap().as_ref().try_into().unwrap());
+        let value = Float128::from_bin_repr(Bytes::from_hex(hex).unwrap().as_bytes().try_into().unwrap());
         check_cross_conversion!(abi, value, Float128, "float128", &repr, hex, &repr, NO_SERDE);
     };
 

--- a/kudu/tests/serialization.rs
+++ b/kudu/tests/serialization.rs
@@ -8,7 +8,7 @@ use serde::{Serialize, Deserialize};
 use serde_json::json;
 
 use kudu::{
-    ABI, ByteStream, ABISerializable,
+    ABI, ABISerializable,
     AntelopeType, AntelopeValue, Asset, Bytes, BlockTimestamp, ExtendedAsset,
     Name, Symbol, SymbolCode, TimePoint, TimePointSec, VarInt32, VarUint32, PublicKey, PrivateKey, Signature,
     Checksum160, Checksum256, Checksum512,
@@ -43,11 +43,11 @@ fn test_encode<T>(obj: T, repr: &str)
 where
     T: ABISerializable + Debug + PartialEq,
 {
-    let mut stream = ByteStream::new();
+    let mut stream = Bytes::new();
 
     // abi.encode(&mut stream, &obj);
     obj.to_bin(&mut stream);
-    assert_eq!(stream.hex_data(), repr,
+    assert_eq!(stream.to_hex(), repr,
                "wrong ABI serialization for: {obj:?}");
 }
 
@@ -56,14 +56,14 @@ fn test_roundtrip<T>(obj: T, repr: &str)
 where
     T: ABISerializable + Debug + PartialEq,
 {
-    let mut stream = ByteStream::new();
+    let mut stream = Bytes::new();
 
     // abi.encode(&mut stream, &obj);
     obj.to_bin(&mut stream);
-    assert_eq!(stream.hex_data(), repr,
+    assert_eq!(stream.to_hex(), repr,
                "wrong serialization for: {obj:?}");
 
-    let decoded = T::from_bin(&mut stream).unwrap();
+    let decoded = T::from_bin(&mut stream.view()).unwrap();
     assert_eq!(decoded, obj,
                "deserialized object `{:?}` is not the same as original one `{:?}`",
                decoded, obj);
@@ -71,13 +71,13 @@ where
 
 #[track_caller]
 fn test_roundtrip_variant(obj: AntelopeValue, repr: &str) {
-    let mut stream = ByteStream::new();
+    let mut stream = Bytes::new();
 
     obj.to_bin(&mut stream);
-    assert_eq!(stream.hex_data(), repr, "wrong serialization for: {obj:?}");
+    assert_eq!(stream.to_hex(), repr, "wrong serialization for: {obj:?}");
 
     let typename: AntelopeType = AntelopeType::from_str(obj.as_ref()).unwrap();
-    let decoded = AntelopeValue::from_bin(typename, &mut stream).unwrap();
+    let decoded = AntelopeValue::from_bin(typename, &mut stream.view()).unwrap();
     assert_eq!(decoded, obj,
                "deserialized object `{:?}` is not the same as original one `{:?}`",
                decoded, obj);
@@ -425,19 +425,19 @@ fn test_bytes() {
 fn test_serialize_array() {
     let a = ["foo", "bar", "baz"];
     let abi = ABI::new();
-    let mut ds = ByteStream::new();
+    let mut ds = Bytes::new();
 
     abi.encode_variant(&mut ds, "string[]", &json!(a)).unwrap();
-    assert_eq!(ds.hex_data().to_uppercase(), "0303666F6F036261720362617A");
+    assert_eq!(ds.to_hex().to_uppercase(), "0303666F6F036261720362617A");
 
     ds.clear();
     abi.encode_variant(&mut ds, "string[][]", &json!([a])).unwrap();
-    assert_eq!(ds.hex_data().to_uppercase(), "010303666F6F036261720362617A");
+    assert_eq!(ds.to_hex().to_uppercase(), "010303666F6F036261720362617A");
 
     ds.clear();
     let v = vec!["foo", "bar", "baz"];
     abi.encode_variant(&mut ds, "string[]", &json!(v)).unwrap();
-    assert_eq!(ds.hex_data().to_uppercase(), "0303666F6F036261720362617A");
+    assert_eq!(ds.to_hex().to_uppercase(), "0303666F6F036261720362617A");
 }
 
 

--- a/kudu/tests/spring_abi_test.rs
+++ b/kudu/tests/spring_abi_test.rs
@@ -188,8 +188,6 @@ fn duplicate_types() -> Result<()> {
 fn nested_types() -> Result<()> {
     init();
 
-    use kudu::ByteStream;
-
     let indirectly_nested_abi = r#"
     {
         "version": "eosio::abi/1.0",
@@ -207,12 +205,12 @@ fn nested_types() -> Result<()> {
     }
     "#;
     let abi = ABI::from_str(indirectly_nested_abi)?;
-    let mut ds = ByteStream::new();
+    let mut ds = Bytes::new();
 
     let value = json!([["a", "b"],["c", "d"]]);
     abi.encode_variant(&mut ds, "name_matrix", &value)?;
 
-    let decoded = abi.decode_variant(&mut ds, "name_matrix")?;
+    let decoded = abi.decode_variant(&mut ds.view(), "name_matrix")?;
     println!("{:?}", decoded);
 
     assert_eq!(value, decoded);
@@ -481,7 +479,7 @@ fn abi_large_array() -> Result<()> {
 
     let data = b"\xff\xff\xff\xff\x08";
 
-    let result = abi.binary_to_variant("hi[]", Bytes(data.to_vec()));
+    let result = abi.binary_to_variant("hi[]", Bytes::from(data));
     check_error!(result, ABIError::DecodeError { .. }, "stream ended unexpectedly; unable to unpack field 'a' of struct 'hi'");
 
     Ok(())
@@ -596,10 +594,10 @@ fn variants() -> Result<()> {
 
     // round-trip abi through multiple formats
     // json -> variant -> abi_def -> bin
-    let mut stream = ByteStream::new();
+    let mut stream = Bytes::new();
     ABIDefinition::from_str(variant_abi)?.to_bin(&mut stream);
     // bin -> abi_def -> variant -> abi_def
-    let abi = ABI::from_str(&json!(ABIDefinition::from_bin(&mut stream)?).to_string())?;
+    let abi = ABI::from_str(&json!(ABIDefinition::from_bin(&mut stream.view())?).to_string())?;
 
     // expected array containing variant
     let result = abi.variant_to_binary("v1", &json!(9));
@@ -646,10 +644,10 @@ fn aliased_variants() -> Result<()> {
 
     // round-trip abi through multiple formats
     // json -> variant -> abi_def -> bin
-    let mut stream = ByteStream::new();
+    let mut stream = Bytes::new();
     ABIDefinition::from_str(aliased_variant)?.to_bin(&mut stream);
     // bin -> abi_def -> variant -> abi_def
-    let abi = ABI::from_str(&json!(ABIDefinition::from_bin(&mut stream)?).to_string())?;
+    let abi = ABI::from_str(&json!(ABIDefinition::from_bin(&mut stream.view())?).to_string())?;
 
     verify_round_trip(&abi, "foo", &json!(["int8",21]), "0015")
 }

--- a/kudune/scripts/build_vaulta_image.py
+++ b/kudune/scripts/build_vaulta_image.py
@@ -49,7 +49,7 @@ def nproc(required_gb_per_core=None):
 
 spring_cdt_source = 'compiled' if COMPILE_SPRING_CDT else 'from package'
 
-logger.warning(f"Installing on: {host.get_fact(LinuxDistribution)['release_meta']['PRETTY_NAME']} (arch: {ARCH})")
+logger.warning(f"Installing on: {DISTRO['PRETTY_NAME']} (arch: {ARCH})")
 logger.warning(f'Host has {SYS_NPROC} CPUs and {SYS_RAM} Gb RAM')
 logger.warning('Installing the following versions:')
 logger.warning(f' - Spring: {SPRING_VERSION} ({spring_cdt_source})')

--- a/kudune/src/docker.rs
+++ b/kudune/src/docker.rs
@@ -2,11 +2,19 @@ use std::fs;
 use std::io::Write;
 
 use color_eyre::{Result, eyre::{eyre, WrapErr}};
+use ratatui::layout::Alignment;
+use ratatui::{
+    prelude::Modifier,
+    widgets::Paragraph,
+};
+use ratatui_macros::{line, span};
+use regex::Regex;
 use serde_json::Value;
 use tempfile::NamedTempFile;
 use tracing::{info, debug, trace, warn};
 
 pub use crate::command::{DockerCommand, DockerCommandJson};
+use crate::ratatui::{make_block, make_table, render, terminal_size};
 
 pub struct Docker {
     /// the container name in which we run the docker commands
@@ -28,9 +36,9 @@ pub struct Docker {
 const HOST_MOUNT_PATH: &str = "/host";
 
 impl Docker {
-    // the Docker constructor is pretty barebones and doesn't ensure
-    // anything is running. You have to call the `start()` method yourself
-    // if you need to ensure the container is running
+    /// the Docker constructor is pretty barebones and doesn't ensure
+    /// anything is running. You have to call the `start()` method yourself
+    /// if you need to ensure the container is running
     pub fn new(container: String, ports: Vec<(u16, u16)>, image: String, host_mount: String) -> Docker {
         Docker { container, ports, image, host_mount }
     }
@@ -46,15 +54,21 @@ impl Docker {
     }
 
     /// Return a `DockerCommand` builder that you can later run inside
-    /// the docker container
-    pub fn command(&self, args: &[&str]) -> DockerCommand {
+    /// the given docker container
+    pub fn docker_container_command(container: &str, args: &[&str]) -> DockerCommand {
         let mut docker_cmd = vec!["container", "exec"];
 
         docker_cmd.extend_from_slice(&["-w", "/app"]);
-        docker_cmd.push(&self.container);
+        docker_cmd.push(container);
         docker_cmd.extend_from_slice(args);
 
         Self::docker_command(&docker_cmd)
+    }
+
+    /// Return a `DockerCommand` builder that you can later run inside
+    /// the docker container
+    pub fn command(&self, args: &[&str]) -> DockerCommand {
+        Self::docker_container_command(&self.container, args)
     }
 
     /// Return a `DockerCommand` builder that you can later run inside
@@ -91,6 +105,105 @@ impl Docker {
     pub fn container_exists(container: &str) -> bool {
         Docker::list_all_containers().into_iter()
             .any(|c| c["Names"].as_str().unwrap() == container)
+    }
+
+    pub fn info(container: &str) -> Result<()> {
+        let get_apt_version = |package| -> String {
+            let pkg_info = String::from_utf8(
+                Self::docker_container_command(container, &["apt-cache", "show", package])
+                    .capture_output(true)
+                    .run()
+                    .stdout
+            ).unwrap();
+            let version_re = Regex::new(r"Version: (.*)\n").unwrap();
+            let caps = version_re.captures(&pkg_info).unwrap();
+            caps.get(1).unwrap().as_str().to_string()
+        };
+        let get_git_version = |folder| -> String {
+            String::from_utf8(
+                Self::docker_container_command(container, &["git", "-C", folder, "describe", "--tags"])
+                    .capture_output(true)
+                    .run()
+                    .stdout
+            ).unwrap().trim().to_string()
+        };
+        let kudune_version = kudu::config::VERSION;
+
+        let (mut width, _height) = terminal_size();
+        width = width.min(100);
+
+        // -----------------------------------------------------------------------------
+        //     print kudune version
+        // -----------------------------------------------------------------------------
+
+        let kudune_version = render(width, 1, |f| {
+            f.render_widget(Paragraph::new(format!("Kudune version: {kudune_version}"))
+                            .alignment(Alignment::Center),
+                            f.area());
+        });
+
+        println!("{}", kudune_version);
+
+        // -----------------------------------------------------------------------------
+        //     print vaulta images
+        // -----------------------------------------------------------------------------
+
+        let images: Vec<_> = Self::list_images().into_iter()
+            .filter(|image| image["Repository"] == "vaulta")
+            .collect();
+
+        let images_output = render(width, (images.len() as u16) + 6, |f| {
+            let block = make_block("Vaulta images");
+            let table = make_table(&images, &["Repository", "Tag", "ID", "CreatedSince", "Size"]);
+            f.render_widget(table.block(block), f.area());
+        });
+
+        println!("{}", images_output);
+
+        // -----------------------------------------------------------------------------
+        //     print vaulta containers
+        // -----------------------------------------------------------------------------
+
+        let containers = Self::list_running_containers();
+        let containers_output = render(width, (containers.len() as u16) + 6, |f| {
+            let block = make_block("Running containers");
+            let table = make_table(&containers, &["ID", "Image", "RunningFor", "Ports", "Names"]);
+            f.render_widget(table.block(block), f.area());
+        });
+
+        println!("{}", containers_output);
+
+        // -----------------------------------------------------------------------------
+        //     print version of the components inside the main container
+        // -----------------------------------------------------------------------------
+
+        if !Self::is_running(container) {
+            // only get info from container if it is running, otherwise exit here
+            return Ok(());
+        }
+
+        let spring_version = get_apt_version("antelope-spring");
+        let cdt_version = get_apt_version("cdt");
+        let system_contracts_version = get_git_version("/app/system_contracts/");
+        let vaulta_contract_version = get_git_version("/app/vaulta_system_contract/");
+
+        let main_container_output = render(width, 8, |f| {
+            // let title = format!("Container: {}", self.docker.container);
+            let title = line!["Container: ", span!(Modifier::BOLD; container)];
+            let block = make_block(title);
+            let paragraph = Paragraph::new(format!(concat!(
+                "- Spring version: {}\n",
+                "- CDT version: {}\n",
+                "- System contracts version: {}\n",
+                "- Vaulta contract version: {}\n"
+            ),
+            spring_version, cdt_version, system_contracts_version, vaulta_contract_version));
+            f.render_widget(paragraph.block(block), f.area());
+        });
+
+        println!("{}", main_container_output);
+
+        Ok(())
     }
 
     /// Start the docker container if needed. Show log output if `log=true`.

--- a/kudune/src/dune.rs
+++ b/kudune/src/dune.rs
@@ -579,21 +579,23 @@ impl Dune {
         // -----------------------------------------------------------------------------
 
         info!("Creating accounts needed for system contracts");
-        self.create_account("eosio.msig", Some("eosio"));
-        self.create_account("eosio.token", Some("eosio"));
         self.create_account("eosio.bpay", Some("eosio"));
+        self.create_account("eosio.msig", Some("eosio"));
         self.create_account("eosio.names", Some("eosio"));
         self.create_account("eosio.ram", Some("eosio"));
         self.create_account("eosio.ramfee", Some("eosio"));
         self.create_account("eosio.saving", Some("eosio"));
         self.create_account("eosio.stake", Some("eosio"));
+        self.create_account("eosio.token", Some("eosio"));
         self.create_account("eosio.vpay", Some("eosio"));
+        self.create_account("eosio.wrap", Some("eosio"));
         self.create_account("eosio.rex", Some("eosio"));
-        self.create_account("eosio.fees", Some("eosio"));  // added in system-contracts v3.4.0
-        self.create_account("eosio.powup", Some("eosio")); // added in system-contracts v3.4.0
+        self.create_account("eosio.fees", Some("eosio"));
+        self.create_account("eosio.reward", Some("eosio"));
+        self.create_account("eosio.wram", Some("eosio"));
+        self.create_account("eosio.reserv", Some("eosio"));
+        self.create_account("eosio.powup", Some("eosio"));
         self.create_account("core.vaulta", Some("eosio"));
-
-        // TODO: missing: eosio.{reward, wram, reserv}, what are they needed for?
 
         // -----------------------------------------------------------------------------
         //     install system contracts

--- a/kudune/src/dune.rs
+++ b/kudune/src/dune.rs
@@ -4,12 +4,6 @@ use std::time::Duration;
 use std::{process, thread};
 
 use color_eyre::eyre::{eyre, Result};
-use ratatui::layout::Alignment;
-use ratatui::{
-    prelude::Modifier,
-    widgets::Paragraph,
-};
-use ratatui_macros::{line, span};
 use regex::Regex;
 use tracing::{debug, info, warn, trace};
 use serde_json::{json, Value};
@@ -18,7 +12,6 @@ use kudu::config::VAULTA_FEATURES;
 use crate::docker::{Docker, DockerCommand};
 use crate::nodeconfig::NodeConfig;
 use crate::util::eyre_from_output;
-use crate::ratatui::{make_block, make_table, render, terminal_size};
 
 
 const DEFAULT_BASE_IMAGE: &str = "ubuntu:22.04";
@@ -123,100 +116,6 @@ impl Dune {
     /// Return a list of all Docker containers (running and stopped) on this machine.
     pub fn list_all_containers(&self) -> Vec<Value> {
         Docker::list_all_containers()
-    }
-
-    pub fn info(&self) -> Result<()> {
-        let get_apt_version = |package| -> String {
-            let pkg_info = String::from_utf8(
-                self.command(&["apt-cache", "show", package])
-                    .capture_output(true)
-                    .run()
-                    .stdout
-            ).unwrap();
-            let version_re = Regex::new(r"Version: (.*)\n").unwrap();
-            let caps = version_re.captures(&pkg_info).unwrap();
-            caps.get(1).unwrap().as_str().to_string()
-        };
-        let get_git_version = |folder| -> String {
-            String::from_utf8(
-                self.command(&["git", "-C", folder, "describe", "--tags"])
-                    .capture_output(true)
-                    .run()
-                    .stdout
-            ).unwrap().trim().to_string()
-        };
-        let kudune_version = kudu::config::VERSION;
-
-        let (mut width, _height) = terminal_size();
-        width = width.min(100);
-
-        // -----------------------------------------------------------------------------
-        //     print kudune version
-        // -----------------------------------------------------------------------------
-
-        let kudune_version = render(width, 1, |f| {
-            f.render_widget(Paragraph::new(format!("Kudune version: {kudune_version}"))
-                            .alignment(Alignment::Center),
-                            f.area());
-        });
-
-        println!("{}", kudune_version);
-
-        // -----------------------------------------------------------------------------
-        //     print vaulta images
-        // -----------------------------------------------------------------------------
-
-        let images: Vec<_> = Docker::list_images().into_iter()
-            .filter(|image| image["Repository"] == "vaulta")
-            .collect();
-
-        let images_output = render(width, (images.len() as u16) + 6, |f| {
-            let block = make_block("Vaulta images");
-            let table = make_table(&images, &["Repository", "Tag", "ID", "CreatedSince", "Size"]);
-            f.render_widget(table.block(block), f.area());
-        });
-
-        println!("{}", images_output);
-
-        // -----------------------------------------------------------------------------
-        //     print vaulta containers
-        // -----------------------------------------------------------------------------
-
-        let containers = Docker::list_running_containers();
-        let containers_output = render(width, (containers.len() as u16) + 6, |f| {
-            let block = make_block("Running containers");
-            let table = make_table(&containers, &["ID", "Image", "RunningFor", "Ports", "Names"]);
-            f.render_widget(table.block(block), f.area());
-        });
-
-        println!("{}", containers_output);
-
-        // -----------------------------------------------------------------------------
-        //     print version of the components inside the main container
-        // -----------------------------------------------------------------------------
-
-        let spring_version = get_apt_version("antelope-spring");
-        let cdt_version = get_apt_version("cdt");
-        let system_contracts_version = get_git_version("/app/system_contracts/");
-        let vaulta_contract_version = get_git_version("/app/vaulta_system_contract/");
-
-        let main_container_output = render(width, 8, |f| {
-            // let title = format!("Container: {}", self.docker.container);
-            let title = line!["Container: ", span!(Modifier::BOLD; self.docker.container)];
-            let block = make_block(title);
-            let paragraph = Paragraph::new(format!(concat!(
-                "- Spring version: {}\n",
-                "- CDT version: {}\n",
-                "- System contracts version: {}\n",
-                "- Vaulta contract version: {}\n"
-            ),
-            spring_version, cdt_version, system_contracts_version, vaulta_contract_version));
-            f.render_widget(paragraph.block(block), f.area());
-        });
-
-        println!("{}", main_container_output);
-
-        Ok(())
     }
 
     /// Given a path to a file or dir on the host, return the equivalent path as

--- a/kudune/src/main.rs
+++ b/kudune/src/main.rs
@@ -241,6 +241,9 @@ fn main() -> Result<()> {
                 println!("Container: {:20} ({})", name, status);
             }
         },
+        Commands::Info => {
+            Docker::info(&cli.container)?;
+        }
         Commands::BuildImage { base, spring, cdt, system_contracts, compile, nproc, no_cleanup } => {
             let compile_info = match compile {
                 true => "(compiled)",
@@ -278,9 +281,6 @@ fn main() -> Result<()> {
             dune.unlock_wallet();
 
             match cmd {
-                Commands::Info => {
-                    dune.info()?;
-                }
                 Commands::WalletPassword => {
                     info!("Wallet password is:");
                     println!("{}", &dune.get_wallet_password());

--- a/kudune/src/main.rs
+++ b/kudune/src/main.rs
@@ -1,7 +1,7 @@
 use std::{env, fs, io, process};
 
 use clap::{Parser, Subcommand, CommandFactory};
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{OptionExt, Result};
 use tracing::{error, info, trace, warn, Level};
 use tracing_subscriber::{EnvFilter, filter::LevelFilter};
 
@@ -210,10 +210,9 @@ fn init_tracing(verbose_level: u8) {
     };
 }
 
-fn parse_mapping(s: &str) -> (u16, u16) {
-     // FIXME: return Err
-    let (a, b) = s.split_once(':').unwrap();
-    (a.parse().unwrap(), b.parse().unwrap())
+fn parse_mapping(s: &str) -> Result<(u16, u16)> {
+    let (a, b) = s.split_once(':').ok_or_eyre("port mapping missing colon ':' char")?;
+    Ok((a.parse()?, b.parse()?))
 }
 
 fn main() -> Result<()> {
@@ -269,11 +268,11 @@ fn main() -> Result<()> {
         // all the other commands need a `Dune` instance, get one now and keep matching
         _ => {
             let home = env::var("HOME").expect("$HOME variable should be set");
-            let ports = cli.ports.split(",").map(parse_mapping).collect();
+            let ports: Result<Vec<_>> = cli.ports.split(",").map(parse_mapping).collect();
             let mut dune = Dune::new(
                 cli.container.clone(),
                 cli.image.clone(),
-                ports,
+                ports?,
                 home,
             )?;
 


### PR DESCRIPTION
- split `ByteStream` into `Bytes` and `ByteStreamView` for better ownership modelling and avoiding unnecessary copies in some places
- minor fixes and quality-of-life enhancements